### PR TITLE
docs(duties): Add ARR guides to EN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 obj/
 bin/
 Lib/
+.idea/
 *.user
 *.log

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
@@ -61,7 +61,7 @@
             ]
         },
         {
-            "Name": "Midgardsormr",
+            "Name": "Midgardsomr",
             "TLDR": "Watch and act quickly to avoid the various types of AOE's\nMake sure to watch the position of the Phantom Kin\nEnsure the Mirage Dragons are killed ASAP to avoid wiping with the following Animadversion\nStay on the stack marker for 4 hits",
             "KeyMechanics": [
                 {

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
@@ -10,7 +10,7 @@
     "Bosses": [
         {
             "Name": "Einhander",
-            "TLDR": "Attack small ceruleum tanks to move them away from the boss.\n\nIf the boss pulls the group in to its location, move out as fast as possible.\n\nCeruleum Tanks\n\tAuxiliary (small) and Main (big) ceruleum tanks will drop around the arena.\n\tSmall tanks can be attacked to knock them across the arena - do this to move all tanks away from the boss.\n\tTanks will eventually begin to glow, indicating that they are about to explode - at this point they can no longer be moved and players should avoid them.",
+            "TLDR": "Make sure to tank the boss pointing away from the party and avoid bombs AOE by standing in the gaps",
             "KeyMechanics": [
                 {
                     "Name": "Resounding Screech",
@@ -36,7 +36,7 @@
         },
         {
             "Name": "Magitek Gunship",
-            "TLDR": "Tanks should keep the boss facing away at all times and be sure to not run back into the Flamethrower too early.\n\nIf targeted by an orange marker, bait the boss along the edge of the arena so that it drops its fire AoEs out of the way of others.",
+            "TLDR": "Tanks should keep the boss facing away at all times and be sure to not run back into the Flamethrower too early.\nAvoid straight-line AOE down arena centre.",
             "KeyMechanics": [
                 {
                     "Name": "Flamethrower",
@@ -62,7 +62,7 @@
         },
         {
             "Name": "Midgardsormr",
-            "TLDR": "Tanks should tank the orange Mirage Dragon far away from the boss, while tanking the blue Mirage Dragon as close to the boss as possible.\n\nPlayers need to activate the magitek shield generator to avoid being hit for heavy damage during Animadversion - tanks be sure to keep dragon adds facing away so that they do not interrupt the activation.",
+            "TLDR": "Watch and act quickly to avoid the various types of AOE's\nMake sure to watch the position of the Phantom Kin\nEnsure the Mirage Dragons are killed ASAP to avoid wiping with the following Animadversion\nStay on the stack marker for 4 hits",
             "KeyMechanics": [
                 {
                     "Name": "Admonishment",

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
@@ -6,5 +6,85 @@
     "Expansion": 0,
     "Level": 50,
     "UnlockQuestID": 65902,
-    "TerritoryID": 150
+    "TerritoryID": 150,
+    "Bosses": [
+        {
+            "Name": "Einhander",
+            "TLDR": "Attack small ceruleum tanks to move them away from the boss.\n\nIf the boss pulls the group in to its location, move out as fast as possible.\n\nCeruleum Tanks\n\tAuxiliary (small) and Main (big) ceruleum tanks will drop around the arena.\n\tSmall tanks can be attacked to knock them across the arena - do this to move all tanks away from the boss.\n\tTanks will eventually begin to glow, indicating that they are about to explode - at this point they can no longer be moved and players should avoid them.",
+            "KeyMechanics": [
+                {
+                    "Name": "Weapons",
+                    "Description": "If the boss has a gun it will fire a column, if it has a staff, it will pull all players and small ceruleum tanks to its location.\n\nGun\n\tWhen the boss is carrying a gun it will attack random players with a column AoE that should be avoided.\n\nStaff\n\tIf the boss is carrying a staff, it will pull all players AND small ceruleum tanks to its location - all players should move out as quickly as possible to avoid exploding tanks.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Mark XLIII Mini Cannon",
+                    "Description": "This attack targets random players with circular AoEs - dodge as necessary.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Heavy Swing",
+                    "Description": "This attack hits directly in front of the boss - tanks should keep the boss facing away from players at all time.",
+                    "Type": 9
+                }
+            ]
+        },
+        {
+            "Name": "Magitek Gunship",
+            "TLDR": "Tanks should keep the boss facing away at all times and be sure to not run back into the Flamethrower too early.\n\nIf targeted by an orange marker, bait the boss along the edge of the arena so that it drops its fire AoEs out of the way of others.",
+            "KeyMechanics": [
+                {
+                    "Name": "Flamethrower",
+                    "Description": "This attack hits directly in front of the boss in a large cone - tanks should keep the boss facing away from the group AND be sure not to run back into the attack too soon.",
+                    "Type": 9
+                },
+                {
+                    "Name": "Garlean Fire",
+                    "Description": "The boss will mark a single player with an orange marker and then follow them around while dropping large fire puddle AoEs - bait the boss around the edge to avoid the puddles from consuming too much space.",
+                    "Type": 6
+                },
+                {
+                    "Name": "Cohort Vanguard",
+                    "Description": "These enemies will spawn during the fight and should be picked up and killed as quickly as possible.",
+                    "Type": 7
+                }
+            ]
+        },
+        {
+            "Name": "Midgardsormr",
+            "TLDR": "Tanks should tank the orange Mirage Dragon far away from the boss, while tanking the blue Mirage Dragon as close to the boss as possible.\n\nPlayers need to activate the magitek shield generator to avoid being hit for heavy damage during Animadversion - tanks be sure to keep dragon adds facing away so that they do not interrupt the activation.",
+            "KeyMechanics": [
+                {
+                    "Name": "Disdain",
+                    "Description": "This attack targets a random player and hits their location with a cirular AoE - move out of the telegraph to avoid damage.\n\nDuring the second half of this fight, the attack will leave a puddle in its place - avoiding running into these.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Admonishment",
+                    "Description": "This attack begins with a large column down the center of the arena, followed by multiple smaller column AoEs - dodge as necessary.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Turmoil",
+                    "Description": "Observe the name of the cast to determine where to stand.\n\nInner Turmoil\n\tThis attack hits the inner half (closest to the boss) with an AoE - avoid as necessary.\n\nOuter Turmoil\n\tThis attack hits the outer area of the arena in a large half donut - stand within melee range to avoid damage.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Mirage Dragons",
+                    "Description": "The boss will always revive the orange dragon first, and the blue dragon second.\nThese adds receive buffs if they are standing too close or too far away from the boss, respectively.\nDuring Animadversion, tanks should be sure to keep the boss facing away from the shield generator or they will interrupt other players trying to activate it.\n\nMirage Dragon (Orange)\n\tThe boss will go invulnerable and revive the orange mirage dragon first.\n\tThis dragon will tether to the boss if it is standing too close to Midgardsormr - tans should keep it facing away from the group and closer to the outer edge of the arena.\n\nMirage Dragon (Blue)\n\tThe boss will revive the blue Mirage Dragon second - this dragon will tether to the boss if it is too far away - tanks should keep it confined to melee range of the boss to avoid this.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Animadversion",
+                    "Description": "This attack is signaled by an Astraea add flying into the arena - killing this add will drop a magitek field generator.\n\nPlayers can interact with this generator to trigger a bubble that will render them immune to Animadversion's damage - all players should stand inside this bubble.\n\nTanks be sure to keep adds facing away from the player who is trying to interact with the generator - adds' attacks can interrupt the action, preventing the shield from being activated in time.",
+                    "Type": 4
+                },
+                {
+                    "Name": "Antipathy",
+                    "Description": "This attack places a circular AoE under a random player which then grows over time before detonating - the targeted player needs to move out of this the moment they notice it or they will be hit.",
+                    "Type": 2
+                }
+            ]
+        }
+    ]
 }

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheKeeperoftheLake.json
@@ -13,19 +13,24 @@
             "TLDR": "Attack small ceruleum tanks to move them away from the boss.\n\nIf the boss pulls the group in to its location, move out as fast as possible.\n\nCeruleum Tanks\n\tAuxiliary (small) and Main (big) ceruleum tanks will drop around the arena.\n\tSmall tanks can be attacked to knock them across the arena - do this to move all tanks away from the boss.\n\tTanks will eventually begin to glow, indicating that they are about to explode - at this point they can no longer be moved and players should avoid them.",
             "KeyMechanics": [
                 {
-                    "Name": "Weapons",
-                    "Description": "If the boss has a gun it will fire a column, if it has a staff, it will pull all players and small ceruleum tanks to its location.\n\nGun\n\tWhen the boss is carrying a gun it will attack random players with a column AoE that should be avoided.\n\nStaff\n\tIf the boss is carrying a staff, it will pull all players AND small ceruleum tanks to its location - all players should move out as quickly as possible to avoid exploding tanks.",
+                    "Name": "Resounding Screech",
+                    "Description": "Summons a group of kin carrying bombs for large scale AOE damage\n\nThe first time, the bombs will be dropped and Mark XLI Quick-Firing Cannon will ignite the first two, stand to one side of the arena away from the two bombs while these two explode, the remaining will then be ignited at which point move to the very edge where one of the first two bombs was.\n\nThe following times the bombs will be dropped with some missing and ignited with Mark XLI Quick-Firing Cannon which will be a raidwide AOE originating in the centre igniting all bombs at once, move to the edge where the missing bombs are to avoid the AOE",
                     "Type": 2
                 },
                 {
-                    "Name": "Mark XLIII Mini Cannon",
-                    "Description": "This attack targets random players with circular AoEs - dodge as necessary.",
-                    "Type": 7
+                    "Name": "Mark XLI Quick-Firing Cannon",
+                    "Description": "This attack is a straight line AOE through the centre of the arena the first time.\nFollowing this it is a raidwide AOE causing more damage closer to the centre of the arena.\nUsed to ignite Bombs from Resounding Screech.",
+                    "Type": 2
                 },
                 {
                     "Name": "Heavy Swing",
-                    "Description": "This attack hits directly in front of the boss - tanks should keep the boss facing away from players at all time.",
+                    "Description": "This attack is a tank targetted cleave - tanks should keep the boss facing away from players at all time.",
                     "Type": 9
+                },
+                {
+                    "Name": "Aero Blast",
+                    "Description": "Raidwide AOE for medium damage",
+                    "Type": 4
                 }
             ]
         },
@@ -35,18 +40,23 @@
             "KeyMechanics": [
                 {
                     "Name": "Flamethrower",
-                    "Description": "This attack hits directly in front of the boss in a large cone - tanks should keep the boss facing away from the group AND be sure not to run back into the attack too soon.",
+                    "Description": "This attack hits directly in front of the boss in a large cone and is continuous for a few seconds - tanks should keep the boss facing away from the group AND be sure not to run back into the attack too soon.",
                     "Type": 9
                 },
                 {
                     "Name": "Garlean Fire",
-                    "Description": "The boss will mark a single player with an orange marker and then follow them around while dropping large fire puddle AoEs - bait the boss around the edge to avoid the puddles from consuming too much space.",
-                    "Type": 6
+                    "Description": "The boss will fly down the centre of the arena the first time while dropping large fire puddle AoEs which disappear after a couple of seconds.\nSubsequent uses he can also turn do another run along the edge after going down the centre.",
+                    "Type": 2
                 },
                 {
                     "Name": "Cohort Vanguard",
                     "Description": "These enemies will spawn during the fight and should be picked up and killed as quickly as possible.",
                     "Type": 7
+                },
+                {
+                    "Name": "Carpet Bomb",
+                    "Description": "Targetted AOE on a random player",
+                    "Type": 2
                 }
             ]
         },
@@ -55,13 +65,8 @@
             "TLDR": "Tanks should tank the orange Mirage Dragon far away from the boss, while tanking the blue Mirage Dragon as close to the boss as possible.\n\nPlayers need to activate the magitek shield generator to avoid being hit for heavy damage during Animadversion - tanks be sure to keep dragon adds facing away so that they do not interrupt the activation.",
             "KeyMechanics": [
                 {
-                    "Name": "Disdain",
-                    "Description": "This attack targets a random player and hits their location with a cirular AoE - move out of the telegraph to avoid damage.\n\nDuring the second half of this fight, the attack will leave a puddle in its place - avoiding running into these.",
-                    "Type": 2
-                },
-                {
                     "Name": "Admonishment",
-                    "Description": "This attack begins with a large column down the center of the arena, followed by multiple smaller column AoEs - dodge as necessary.",
+                    "Description": "This is a large column AOE down the center of the arena which can be avoided",
                     "Type": 2
                 },
                 {
@@ -70,19 +75,39 @@
                     "Type": 2
                 },
                 {
+                    "Name": "Phantom Kin",
+                    "Description": "One dragons gets summoned to each side of the arena, pay attention to which direction they are facing and pick a location where there is a gap in their gaze, the boss will then do one of his other abilities with \"Phantom\" in front (ie. Phantom Admonishment), when this ability casts the two dragons will do a straight line AOE across the arena each that takes up about 1/3 of the arena each. It is an AOE with a short period between marking and attack so make sure to pay attention to their gaze and the follow-up cast used to pre-position safely.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Disgust",
+                    "Description": "Raidwide AOE with minor damage",
+                    "Type": 2
+                },
+                {
                     "Name": "Mirage Dragons",
-                    "Description": "The boss will always revive the orange dragon first, and the blue dragon second.\nThese adds receive buffs if they are standing too close or too far away from the boss, respectively.\nDuring Animadversion, tanks should be sure to keep the boss facing away from the shield generator or they will interrupt other players trying to activate it.\n\nMirage Dragon (Orange)\n\tThe boss will go invulnerable and revive the orange mirage dragon first.\n\tThis dragon will tether to the boss if it is standing too close to Midgardsormr - tans should keep it facing away from the group and closer to the outer edge of the arena.\n\nMirage Dragon (Blue)\n\tThe boss will revive the blue Mirage Dragon second - this dragon will tether to the boss if it is too far away - tanks should keep it confined to melee range of the boss to avoid this.",
-                    "Type": 7
+                    "Description": "The boss will summon two Mirage Dragons in the middle of the arena which both need to be killed quickly, the higher Midgardsormr's Aether the more damage the following Animadversion will do, reaching 100 is instant wipe.",
+                    "Type": 8
                 },
                 {
                     "Name": "Animadversion",
-                    "Description": "This attack is signaled by an Astraea add flying into the arena - killing this add will drop a magitek field generator.\n\nPlayers can interact with this generator to trigger a bubble that will render them immune to Animadversion's damage - all players should stand inside this bubble.\n\nTanks be sure to keep adds facing away from the player who is trying to interact with the generator - adds' attacks can interrupt the action, preventing the shield from being activated in time.",
+                    "Description": "Moderate damage raidwide AOE.",
                     "Type": 4
                 },
                 {
+                    "Name": "Akh Morn",
+                    "Description": "Targets a random player indicated by a Stack Marker which all players should stack on to distribute the damage, will hit once, followed by a short pause, this then hits 3 more times in quick succession and players should not move from the stack until all have hit.",
+                    "Type": 3
+                },
+                {
                     "Name": "Antipathy",
-                    "Description": "This attack places a circular AoE under a random player which then grows over time before detonating - the targeted player needs to move out of this the moment they notice it or they will be hit.",
+                    "Description": "This attack places a circular AoE in the centre of the arena which then grows in rings over time before detonating in the same order they were placed.\nPlayers should stand in the second ring just at the edge of the first and move into the position of the first as soon as it detonates to avoid being hit by the second ring.",
                     "Type": 2
+                },
+                {
+                    "Name": "Condescension",
+                    "Description": "Targetted AOE on the tank with no area marker hitting for minor damage if only a single target is hit. Tank should move away from players",
+                    "Type": 0
                 }
             ]
         }

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheLostCityofAmdapor.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheLostCityofAmdapor.json
@@ -6,5 +6,75 @@
     "Expansion": 0,
     "Level": 50,
     "UnlockQuestID": 66925,
-    "TerritoryID": 363
+    "TerritoryID": 363,
+    "Bosses": [
+        {
+            "Name": "Wamoura",
+            "TLDR": "Ensure that you focus down the Voracious Maw when it spawns so your teammate doesn't die.",
+            "KeyMechanics": [
+                {
+                    "Name": "Dirty Sneeze",
+                    "Description": "Frontal cone AoE. Avoid facing the group.",
+                    "Type": 9
+                },
+                {
+                    "Name": "Moldy Phlegm",
+                    "Description": "Targets a random player with an AoE. Leaves behind an AoE puddle that applies a DoT.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Voracious Maw",
+                    "Description": "Prey mechanic. The boss will tether to a random player and the message \"The decaying gourmand marks his prey!\" will appear. Running over the player will transfer the prey marker. After a few seconds, the player will be sucked into the boss' stomach, and the Voracious Maw will become targetable. Players need to kill it ASAP to free their teammate. If the party fails to do so within a certain amount of time, the player will be killed.",
+                    "Type": 6
+                }
+            ]
+        },
+        {
+            "Name": "Arioch",
+            "TLDR": "The boss is attracted to the player with the largest amount of Scale Flake stacks, so make sure the tank has more of those than anyone else.\n\nScale Flakes also makes players take more damage, so limit how many stacks you're picking up.\n\nPull another Ranch Wamoura at 10-15 seconds left on Scale Flakes.",
+            "KeyMechanics": [
+                {
+                    "Name": "Ranch Wamoura",
+                    "Description": "Spawns throughout the fight. Used to bring the boss down to fight.\n\nPoison Dust\n\tAvoidable frontal cone AoE that applies a 30-second stackable Poison debuff that can be dispeled.\n\nScale Flakes\n\tUsed just before it dies. An unmarked frontal cone AoE that applies a 45-second stacking debuff on players caught in the AoE. Used to attract the boss. Increases damage taken as well.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Eerie Soundwave",
+                    "Description": "Roomwide AoE damage.",
+                    "Type": 4
+                },
+                {
+                    "Name": "Corrosive Gale",
+                    "Description": "Long line AoE on a random player.",
+                    "Type": 2
+                }
+            ]
+        },
+        {
+            "Name": "Diabolos",
+            "TLDR": "It is possible to live through skipping the first set of Gates during Ruinous Omen, which generally gives you enough DPS to kill the boss before the second set.\n\nWait until 1/2 to 3/4 through Ruinous Omen before opening the Gates so you can avoid the damage from the ability.",
+            "KeyMechanics": [
+                {
+                    "Name": "Diabolic Gates",
+                    "Description": "There are 8 gates that spawn, with each gate \"paired\" to another by way of matching symbols. After a few seconds, the symbols will be covered and the doors will close. Players need to remember where at least 1 matching pair is. Open one of the doors first, and then mark the other one so you know which to open during Ruinous Omen. Whenever a matched set is opened, the other symbols will be revealed, allowing you to find another set.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Graviball",
+                    "Description": "Targets a random player and drops an orb on them that pulses every few seconds, dealing moderate damage in an extra large AoE around it.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Ruinous Omen",
+                    "Description": "Boss Ultimate. Deals heavy damage to all players caught in it (~80%). Negated by opening matching Diabolic Gates.",
+                    "Type": 4
+                },
+                {
+                    "Name": "Ultimate Terror",
+                    "Description": "Donut AoE. Be in melee range or max cast range.",
+                    "Type": 2
+                }
+            ]
+        }
+    ]
 }

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheStoneVigil_Hard.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheStoneVigil_Hard.json
@@ -6,5 +6,100 @@
     "Expansion": 0,
     "Level": 50,
     "UnlockQuestID": 67061,
-    "TerritoryID": 365
+    "TerritoryID": 365,
+    "Bosses": [
+        {
+            "Name": "Gorynich",
+            "TLDR": "Try to keep the boss away from the dying Vigil Heirs so they don't buff him.\n\nMove with the boss when he trundles away from the tank; usually he's going to use Swinge and you want to be avoiding that.",
+            "KeyMechanics": [
+                {
+                    "Name": "Swinge",
+                    "Description": "Massive frontal cone AoE. Majority of the time, the boss will move to an edge of the room and turn to face the room before using this. Make sure to move with the boss and stand on his sides or behind him to avoid being hit.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Lion's Breath",
+                    "Description": "Frontal cone AoE.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Rake",
+                    "Description": "Tankbuster.",
+                    "Type": 0
+                },
+                {
+                    "Name": "Vigil Heirs",
+                    "Description": "Spawns multiple waves of these adds throughout the fight. If they die near Gorynich, they will buff him with stacks of haste and increased damage dealt. They will also use Agony when they die.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Agony",
+                    "Description": "Used by the Vigil Heirs on their death. Will either be a massive frontal cone AoE or a massive circle AoE centered on the monster.",
+                    "Type": 2
+                }
+            ]
+        },
+        {
+            "Name": "Cuca Fera",
+            "TLDR": "This boss can't be attacked the traditional way; instead, players will need to use the 4 Bertha cannons to DPS him down.",
+            "KeyMechanics": [
+                {
+                    "Name": "Bertha",
+                    "Description": "Your immobile cannon companion. Grants you 2 abilities on your pet hotbar\n\nIron Kiss\n\tThe only way you can damage the boss. Has a short cast time and shares GCD with all of your skills.\n\nSpindly Finger\n\tStuns targets in the area of the AoE. Has a 30-second cooldown. Used to stop Hard Stomp.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Diamondback",
+                    "Description": "Causes the boss to reflect all damage. Immediately stop shooting the Bertha cannons at the boss. Lasts for 6 seconds, and his shell will flash red for the duration of use.",
+                    "Type": 5
+                },
+                {
+                    "Name": "Hard Stomp",
+                    "Description": "A massive AoE that deals heavy damage. Can be canceled with Spindly Finger.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Adds",
+                    "Description": "Spawns a few waves of adds throughout the fight that must be killed. Best to use Iron Kiss for this. Mobs that get too close to the cannon can't be hit so target the ones on the other side of the room. Can kill the Bertha's if not careful.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Whipstream",
+                    "Description": "The boss engulfs itself in flame and charges one of the Bertha's.",
+                    "Type": 6
+                }
+            ]
+        },
+        {
+            "Name": "Giruveganaus",
+            "TLDR": "Important to note that you cannot hold aggro on this fight.\n\nIt may be easier to burn down one of the bosses before starting the other so there is less stuff to dodge.\n\nBoth bosses use the same abilities.",
+            "KeyMechanics": [
+                {
+                    "Name": "Wild Charge",
+                    "Description": "The boss takes a runner's stance and drops his right shoulder before dashing forwards, dealing damage and knocking back players in its path and applying an Infirmity debuff.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Tail Swipe",
+                    "Description": "The boss raises his tail before swiping behind him in a...backwards cone. Applies an Infirmity debuff.",
+                    "Type": 9
+                },
+                {
+                    "Name": "Claw Slash",
+                    "Description": "The boss raises one of his paws before slashing forward in a frontal cone. Applies an Infirmity debuff.",
+                    "Type": 9
+                },
+                {
+                    "Name": "Fireball",
+                    "Description": "The boss leans back and sucks in energy/air before spitting a fireball at a random player. Leaves behind a fire puddle. Applies an Infirmity debuff.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Add",
+                    "Description": "A second boss will spawn when the first reaches ~60%. Both must be killed to finish the fight, but don't need to be killed at the same time.",
+                    "Type": 7
+                }
+            ]
+        }
+    ]
 }

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheSunkenTempleofQarn_Hard.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheSunkenTempleofQarn_Hard.json
@@ -6,5 +6,100 @@
     "Expansion": 0,
     "Level": 50,
     "UnlockQuestID": 65632,
-    "TerritoryID": 367
+    "TerritoryID": 367,
+    "Bosses": [
+        {
+            "Name": "Damaged Adjudicator",
+            "TLDR": "There will be 3 Glowing Core phases before you can finish off the boss' body.\n\nThe phase won't push if you kill the wrong Body Part. Make sure you're targeting the Glowing Core one.",
+            "KeyMechanics": [
+                {
+                    "Name": "Body Parts",
+                    "Description": "The Head, Tail, and Arm of the Adjudicator will be vulnerable to attack. However, only one of the parts will temporarily down him: the one with the Glowing Core.",
+                    "Type": 5
+                },
+                {
+                    "Name": "Glowing Core",
+                    "Description": "Each time the boss reassembles itself, one of the Body Parts will glow with a bright red orb for a few seconds before fading. Target that part to break the boss apart and move to the next part.",
+                    "Type": 5
+                },
+                {
+                    "Name": "Dust to Dust",
+                    "Description": "Targets a random player with a large orange arrow marker. after a short time, a sand ball will spawn on top of that player and remain there for some time, pulsing out large AoEs that deal moderate damage.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Shifting Sands",
+                    "Description": "Spawns an extra large AoE puddle on the ground (generally centered on a player) that will slowly suck you into the sand. If you stay in it for more than ~10 seconds, you will die.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Adds",
+                    "Description": "After breaking the correct Body Part, the boss will collapse and spawn numerous adds. Kill them ASAP to make the boss stand back up again.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Sandblast",
+                    "Description": "Unmarked frontal cone AoE on the MT. Keep facing away from the group.",
+                    "Type": 9
+                }
+            ]
+        },
+        {
+            "Name": "Sabotender Emperatriz",
+            "TLDR": "Make sure to kill the Sabotender Guardia right away so you can attack the boss to cancel 100,000 Needles.",
+            "KeyMechanics": [
+                {
+                    "Name": "100,000 Needles",
+                    "Description": "Long cast time that is only interupted through damage. If not interupted, instant wipe. Burn the boss ASAP to prevent this. Be sure to kill the tethered Sabotender Guardia so you can cancel this skill.",
+                    "Type": 8
+                },
+                {
+                    "Name": "3,000 Needles",
+                    "Description": "Targets a random player for a large AoE circle.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Adds",
+                    "Description": "Will spawn waves of adds throughout the fight. You can either collect and kite them around, have the tank hold them, or kill them. There are a few adds you need to keep an eye out for\n\nSabotender Campeador\n\tExtra large sabotender wielding a large club. Targets the healer and should be killed quickly.\n\nSabotender Guardia\n\tSimilar appearance to the Campeador. However, will immediately use a version of cover on the boss as it begins to cast 100,000 Needles. Must be killed ASAP before you can begin damaging the boss.",
+                    "Type": 7
+                }
+            ]
+        },
+        {
+            "Name": "Vicegerent To The Warden",
+            "TLDR": "If the tank gets Mummified, the boss will pick a new target until they are unmummified.\n\nAnyone who gets mummified will have to wait until the next round of Mummy Walls, which can take quite a while.\n\nThink of the room as a 3x3 rectangle to figure out where to move for the Mummy Walls.",
+            "KeyMechanics": [
+                {
+                    "Name": "Curse of the Mummy",
+                    "Description": "A stacking debuff applied through most of the abilities used by the boss. Reaching a stack of 4 will Mummify you.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Mummify",
+                    "Description": "After getting 4 Curse of the Mummy' stacks, the player will lose control and run to a sarcophagus at one of the four corners of the room. When the next Mummy Walls comes up, the player will run diagonally across the room with the other mummies before returning to normal. Any players hit during this run or who were standing in the sarcophagus will gain increasing stacks of Curse of the Mummy.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Mummy Walls",
+                    "Description": "Two rows of sarcophagi will appear around the room with a reddish black puddle beneath them. After a few seconds, mummies will run out of the sarcophagi and in a straight line across the room where they will disappear. Anyone standing in the puddle or in the path of the mummies will gain increasing stacks of Curse of the Mummy. ",
+                    "Type": 2
+                },
+                {
+                    "Name": "Light of Anathema",
+                    "Description": "Targets a random player and turns to them, crossing its blades that are now glowing purple. After a few seconds, it will slice outwards with them, leaving a long line AoE in a straight line before him. Applies stacks of Curse of the Mummy. Often used multiple times in a row.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Flurry of Rage",
+                    "Description": "Targets a random player for a frontal cleave. Applies stacks of Curse of the Mummy.",
+                    "Type": 9
+                },
+                {
+                    "Name": "Mummy Tether",
+                    "Description": "The boss will tether to a random player and walk towards them, applying stacks of Curse of the Mummy. Players should stun the boss and the affected player should immediately sprint away from the boss to break the tether.",
+                    "Type": 6
+                }
+            ]
+        }
+    ]
 }

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheTamTaraDeepcroft_Hard.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheTamTaraDeepcroft_Hard.json
@@ -6,5 +6,85 @@
     "Expansion": 0,
     "Level": 50,
     "UnlockQuestID": 67060,
-    "TerritoryID": 373
+    "TerritoryID": 373,
+    "Bosses": [
+        {
+            "Name": "Liavinne",
+            "TLDR": "It's easiest to just have the entire group stack on the boss so no one needs to chase after the adds to kill them with Rotting Arrow.\n\nNever kill the adds yourself; let Rotting Arrow do the work for you.",
+            "KeyMechanics": [
+                {
+                    "Name": "Instability",
+                    "Description": "Throws three red orbs at a random player, marking them as the target of the Best Men.",
+                    "Type": 6
+                },
+                {
+                    "Name": "Rotting Arrow",
+                    "Description": "Targets a random player with a large red arrow marker. After a few seconds, they will be targeted for a large AoE that deals damage to both players and the Best Men around them.",
+                    "Type": 6
+                },
+                {
+                    "Name": "Best Men",
+                    "Description": "Spawns increasingly more adds throughout the fight. Will singlemindedly attack the player marked by Instability. Killing them yourselves will cause them to explode to deal light damage and apply a Vulnerability Up debuff. By hitting them with Rotting Arrow, no one is damaged and no debuffs are applied.",
+                    "Type": 7
+                }
+            ]
+        },
+        {
+            "Name": "Spare Body",
+            "TLDR": "Two extra large Orbs will spawn near the end of the fight that deal heavy damage.\n\nThe tank should keep the boss against the edge of the arena, avoiding Orbs and moving out of Cloudcover as necessary.",
+            "KeyMechanics": [
+                {
+                    "Name": "Paiyo Reiyo",
+                    "Description": "Appears in the center of the arena and is locked in place. Must be kept alive. If he dies, the group will wipe and have to restart. He can be healed if necessary.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Portals",
+                    "Description": "Seven void portals will spawn along the edge of the arena that spit out Orbs occasionally.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Orbs",
+                    "Description": "Spawn from the Portals. Slowly move towards the center of the room. Will deal damage to Paiyo Reiyo. Players need to intercept these orbs with their own bodies, causing them to explode. If the boss gets near any orbs, it will grant him a stacking Damage Up buff while increasing his size. For this reason, the tank should avoid picking up the orbs.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Cloudcover",
+                    "Description": "Targets the tank for a large circle AoE puddle. Standing in it applies a Bleed DoT.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Iron Justice",
+                    "Description": "Frontal cleave on the MT. Keep the boss facing away from the group.",
+                    "Type": 9
+                }
+            ]
+        },
+        {
+            "Name": "Avere Bravearm & Edda Pureheart",
+            "TLDR": "Kill the Grooms-to-be ASAP so you don't need to worry about the Runes.\n\nThe portal adds will appear in larger numbers, using increasing amounts of AoE as the fight goes on. Be ready to squeeze into tiny safe spots between the overlapping AoEs.",
+            "KeyMechanics": [
+                {
+                    "Name": "Runes",
+                    "Description": "Numerous large, dark red runes appear around the puddle in the center of the room. One will light up for each Groom-to-be that reaches the center of the room. Increases the damage dealt by Red Wedding.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Portals",
+                    "Description": "Numerous portals spawn along the edges of the room. Occasionally, untargetable adds will appear from them, using various AoEs. Also spawns Grooms-to-be.\n\nWalkgoyles\n\tuse long line AoEs\n\nFlygoyles\n\tuse large circle AoEs",
+                    "Type": 7
+                },
+                {
+                    "Name": "Groom-to-be",
+                    "Description": "Will appear from a portal and begin crawling towards the center of the room. Must be killed ASAP. Every groom that reaches the center will charge up a Rune.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Red Wedding",
+                    "Description": "Used after each Groom-to-be phase or immediately if all Runes are lit up. Deals increased damage for each Rune that is lit up.",
+                    "Type": 4
+                }
+            ]
+        }
+    ]
 }

--- a/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheWanderersPalace_Hard.json
+++ b/src/Resources/Localization/Duty/en/A Realm Reborn/Dungeons/TheWanderersPalace_Hard.json
@@ -6,5 +6,110 @@
     "Expansion": 0,
     "Level": 50,
     "UnlockQuestID": 65967,
-    "TerritoryID": 188
+    "TerritoryID": 188,
+    "Bosses": [
+        {
+            "Name": "Frumious Koheel Ja",
+            "TLDR": "DPS must destroy the Sacred Spears when they appear. At around 33% he will use this twice in a row, leaving two spears to destroy.\n\nFairly simple tank and spank boss aside from the spears.",
+            "KeyMechanics": [
+                {
+                    "Name": "Batterhorn",
+                    "Description": "Inflicts damage and knockback.",
+                    "Type": 0
+                },
+                {
+                    "Name": "Fire Angon",
+                    "Description": "Fire damage to a random party member.",
+                    "Type": 6
+                },
+                {
+                    "Name": "Blazing Angon",
+                    "Description": "Tosses a Sacred Spear into the ground, which periodically uses a skill likewise called Blazing Angon to inflict roomwide fire damage and apply a stacking Burns debuff which deals fire damage over time.",
+                    "Type": 8
+                },
+                {
+                    "Name": "Burning Memories",
+                    "Description": "Targeted AoE damage on a random party member. Can be avoided.",
+                    "Type": 2
+                }
+            ]
+        },
+        {
+            "Name": "Slithy Zolool Ja",
+            "TLDR": "The colors of the standards and their buffs/debuffs vary each time. The first time it is used, only the Heavy, Fire Resistance Down, and Damage Up totems will spawn. Figure out which one is the Damage Up totem, and the missing color will always be the Toad totem.\n\nIt's beneficial for the DPS to figure out which is the Damage Up standard as it grants them a buff. Later in the fight, there are multiple Damage Up standards so multiple members can receive the buff.",
+            "KeyMechanics": [
+                {
+                    "Name": "Fire",
+                    "Description": "Fire damage to the tank",
+                    "Type": 0
+                },
+                {
+                    "Name": "Groundburst",
+                    "Description": "AoE damage to a random party member. Instant cast.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Firespit",
+                    "Description": "Heavy fire damage to the tank.",
+                    "Type": 0
+                },
+                {
+                    "Name": "Sacred Standard",
+                    "Description": "Summons a varying amount of standards around the battlefield that give buffs or debuffs when entered. There will be a blue, green, red, and purple standard, one will inflict Heavy, another inflicts Fire Resistance Down (very dangerous), one grants Damage Up, and one will toggle Toad status, either inflicting it if normal or removing it if toaded.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Standard Retrieval",
+                    "Description": "Recalls his standards, and any Damage Up totems that are still up will give him a stack of Damage Up.",
+                    "Type": 10
+                },
+                {
+                    "Name": "Toad",
+                    "Description": "Inflicts the Toad status on a player, preventing them from taking any actions for the duration. Removed by one of the standards, or waiting it out.",
+                    "Type": 6
+                }
+            ]
+        },
+        {
+            "Name": "Manxome Molaa Ja Ja",
+            "TLDR": "The boss should be tanked as close to the wall as possible. Whenever he drops a Sacred Standard, follow the wall until he is just barely not standing in it (you can see it on his buffs). When he drops a Sacred Idol, just keep him still and DPS down the Idol.\n\nIt's best to stand close to the boss so you can more easily dodge Tyrannic Blare.\n\nThe healer needs to keep an eye on the debuffs of party members so they know who ends up marked with Soul Douse to prevent unwanted deaths.",
+            "KeyMechanics": [
+                {
+                    "Name": "Rushing Slash",
+                    "Description": "Physical damage to the tank.",
+                    "Type": 0
+                },
+                {
+                    "Name": "Tyrannic Blare",
+                    "Description": "Conal attack that inflicts Stun and Magic Vulnerability Up. Has long range and targets a random party member, so ranged units are advised to stay close to him.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Rot Gas",
+                    "Description": "Inflicts poison and heavy.",
+                    "Type": 2
+                },
+                {
+                    "Name": "Vorpal Wheel",
+                    "Description": "Ranged attack that inflicts Rotting Lungs, which will cause the target to explode if damaged by Rot Gas.",
+                    "Type": 6
+                },
+                {
+                    "Name": "Soul Douse",
+                    "Description": "Inflicts a version of Doom that will kill the target if they are not healed to full HP before it wears off.",
+                    "Type": 6
+                },
+                {
+                    "Name": "Sacred Standard",
+                    "Description": "Not a move, he summons these occasionally. They are very difficult to destroy, and will buff him with Damage Up and Vulnerability Down so long as he remains inside the circle. The tank should rotate him around the arena to stay out of them.",
+                    "Type": 7
+                },
+                {
+                    "Name": "Sacred Idol",
+                    "Description": "Very similar to the standard, but will buff the boss no matter where he is. DPS can easily destroy it however.",
+                    "Type": 7
+                }
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
### Changes
All ARR Dungeons now have some form of EN guide.

Added ARR Instance Guides for:
- The Keeper of the Lake
- The Lost City of Amdapor
- The Stone Vigil (Hard)
- The Sunken Temple of Qarn (Hard)
- The Tam-Tara Deepcroft (Hard)
- The Wanderers Palace (Hard)

Taken from various guides so formats may not match.

Also added IntelliJ Idea workspace directory to .gitignore
  
#### Licensing
- [x] I agree to license my work under the repository LICENSE.
